### PR TITLE
Initialize Stripe when the rest of the theme scripts load

### DIFF
--- a/components/cart/stripe.htm
+++ b/components/cart/stripe.htm
@@ -8,68 +8,70 @@
     <input type="hidden" name="checkout[token]" value="" id="stripe-token">
 </div>
 
-<script>
-    $(function () {
+{% put scripts %}
+    <script>
+        $(function () {
 
-        if (!window.stripeLoaded) {
-            {# Lazy load stripe.js to ensure everything works when changing the payment method. #}
-            var s = document.createElement('script');
-            s.type = 'text/javascript';
-            s.src = 'https://js.stripe.com/v3/';
-            s.onload = initStripe;
+            if (!window.stripeLoaded) {
+                {# Lazy load stripe.js to ensure everything works when changing the payment method. #}
+                var s = document.createElement('script');
+                s.type = 'text/javascript';
+                s.src = 'https://js.stripe.com/v3/';
+                s.onload = initStripe;
 
-            document.head.appendChild(s)
-        } else {
-            initStripe()
-        }
-
-        function initStripe () {
-            var stripe = Stripe('{{ method.settings.stripe_publishable_key }}');
-            var elements = stripe.elements();
-            var form = document.getElementById('checkout')
-
-            var card = elements.create('card');
-            card.mount('#card-element');
-
-            card.addEventListener('change', function (event) {
-                var displayError = document.getElementById('card-errors');
-                if (event.error) {
-                    displayError.textContent = event.error.message;
-                } else {
-                    displayError.textContent = '';
-                }
-            });
-
-            form.removeEventListener('offline.microcart.checkout', checkoutHandler, true);
-            form.addEventListener('offline.microcart.checkout', checkoutHandler, true);
-
-            window.stripeLoaded = true
-
-            function checkoutHandler (event) {
-                // Tell the form submission that we're handling it via the Promise attached to the Event.
-                if (event.detail.isHandled) {
-                    return
-                }
-                event.detail.isHandled = true
-
-                var submit = form.querySelector('[type="submit"]')
-                submit.classList.add('oc-loading')
-                submit.disabled = true
-
-                stripe.createToken(card).then(function (result) {
-                    if (result.error) {
-                        var errorElement = document.getElementById('card-errors');
-                        errorElement.textContent = result.error.message;
-                        submit.classList.remove('oc-loading')
-                        event.detail.reject()
-                    } else {
-                        var input = document.getElementById('stripe-token')
-                        input.value = result.token.id
-                        event.detail.resolve()
-                    }
-                    submit.disabled = false
-                });
+                document.head.appendChild(s)
+            } else {
+                initStripe()
             }
-        }
-    });
-</script>
+
+            function initStripe () {
+                var stripe = Stripe('{{ method.settings.stripe_publishable_key }}');
+                var elements = stripe.elements();
+                var form = document.getElementById('checkout')
+
+                var card = elements.create('card');
+                card.mount('#card-element');
+
+                card.addEventListener('change', function (event) {
+                    var displayError = document.getElementById('card-errors');
+                    if (event.error) {
+                        displayError.textContent = event.error.message;
+                    } else {
+                        displayError.textContent = '';
+                    }
+                });
+
+                form.removeEventListener('offline.microcart.checkout', checkoutHandler, true);
+                form.addEventListener('offline.microcart.checkout', checkoutHandler, true);
+
+                window.stripeLoaded = true
+
+                function checkoutHandler (event) {
+                    // Tell the form submission that we're handling it via the Promise attached to the Event.
+                    if (event.detail.isHandled) {
+                        return
+                    }
+                    event.detail.isHandled = true
+
+                    var submit = form.querySelector('[type="submit"]')
+                    submit.classList.add('oc-loading')
+                    submit.disabled = true
+
+                    stripe.createToken(card).then(function (result) {
+                        if (result.error) {
+                            var errorElement = document.getElementById('card-errors');
+                            errorElement.textContent = result.error.message;
+                            submit.classList.remove('oc-loading')
+                            event.detail.reject()
+                        } else {
+                            var input = document.getElementById('stripe-token')
+                            input.value = result.token.id
+                            event.detail.resolve()
+                        }
+                        submit.disabled = false
+                    });
+                }
+            }
+        });
+    </script>
+{% endput %}


### PR DESCRIPTION
This fixes an issue where Stripe was attempting to initialize before jQuery was ready because it was executing in it's place in the document order when the scripts for the theme are placed at the end of the body element so they haven't been loaded yet. Putting this script inside of the {% scripts %} tag will ensure that it's always loaded after jQuery (assuming that the theme developer has correctly implemented the `{% scripts %}` tag. Either way it's more robust than the current approach.